### PR TITLE
db.SetMaxOpenConns(100)

### DIFF
--- a/webapp/golang/app.go
+++ b/webapp/golang/app.go
@@ -820,6 +820,7 @@ func main() {
 	)
 
 	db, err = sqlx.Open("mysql", dsn)
+	db.SetMaxIdleConns(200)
 	if err != nil {
 		log.Fatalf("Failed to connect to DB: %s.", err.Error())
 	}

--- a/webapp/golang/app.go
+++ b/webapp/golang/app.go
@@ -820,7 +820,7 @@ func main() {
 	)
 
 	db, err = sqlx.Open("mysql", dsn)
-	db.SetMaxIdleConns(200)
+	db.SetMaxOpenConns(200)
 	if err != nil {
 		log.Fatalf("Failed to connect to DB: %s.", err.Error())
 	}

--- a/webapp/golang/app.go
+++ b/webapp/golang/app.go
@@ -820,7 +820,7 @@ func main() {
 	)
 
 	db, err = sqlx.Open("mysql", dsn)
-	db.SetMaxOpenConns(200)
+	db.SetMaxOpenConns(100)
 	if err != nil {
 		log.Fatalf("Failed to connect to DB: %s.", err.Error())
 	}


### PR DESCRIPTION
#1 
```
mysql> show global variables like '%connection%';
+-----------------------------------+----------------------+
| Variable_name                     | Value                |
+-----------------------------------+----------------------+
| character_set_connection          | utf8mb4              |
| collation_connection              | utf8mb4_0900_ai_ci   |
| connection_memory_chunk_size      | 8192                 |
| connection_memory_limit           | 18446744073709551615 |
| global_connection_memory_limit    | 18446744073709551615 |
| global_connection_memory_tracking | OFF                  |
| max_connections                   | 300                  |
| max_user_connections              | 0                    |
| mysqlx_max_connections            | 100                  |
+-----------------------------------+----------------------+
```
max_connectionsがいつもより多い300。試しに200もやってみた

200で
```
{"pass":true,"score":37650,"success":35516,"fail":0,"messages":[]}
```

100で
```
{"pass":true,"score":39196,"success":37038,"fail":0,"messages":[]}
```

得点の高かった100にする